### PR TITLE
Define exception classes for 503 and 504 responses

### DIFF
--- a/lib/swiftype/exceptions.rb
+++ b/lib/swiftype/exceptions.rb
@@ -6,4 +6,10 @@ module Swiftype
   class BadRequest < ClientException; end
   class Forbidden < ClientException; end
   class UnexpectedHTTPException < ClientException; end
+
+  class ServerException < StandardError; end
+  class InternalServerError < ServerException; end
+  class BadGateway < ServerException; end
+  class ServiceUnavailable < ServerException; end
+  class GatewayTimeout < ServerException; end
 end

--- a/lib/swiftype/request.rb
+++ b/lib/swiftype/request.rb
@@ -105,7 +105,11 @@ module Swiftype
       Net::HTTPNotFound => Swiftype::NonExistentRecord,
       Net::HTTPConflict => Swiftype::RecordAlreadyExists,
       Net::HTTPBadRequest => Swiftype::BadRequest,
-      Net::HTTPForbidden => Swiftype::Forbidden
+      Net::HTTPForbidden => Swiftype::Forbidden,
+      Net::HTTPInternalServerError => Swiftype::InternalServerError,
+      Net::HTTPBadGateway => Swiftype::BadGateway,
+      Net::HTTPServiceUnavailable => Swiftype::ServiceUnavailable,
+      Net::HTTPGatewayTimeOut => Swiftype::GatewayTimeout
     }.freeze
 
     def error_message_from_response(response)


### PR DESCRIPTION
We've received a small number of these responses from Swiftype but, since they were raised as `UnexpectedHTTPException` errors, we weren't able to handle them specifically (for example, by waiting a period of time and then retrying the request). Instead, we could only handle them generically (as unexpected runtime errors).